### PR TITLE
fix(deps): restrict zarr to <3.0.0 to prevent breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     ],
     extras_require={
         "tests": [
-            "zarr",
+            "zarr<3.0.0",
             "mypy",
             "black",
             "dask",


### PR DESCRIPTION
zarr 3.0.0 introduced many breaking changes, to the API and for fsspec integration. 

In order to maintain compatibility, the dependency constraint on zarr was added as "<3.0.0".

Sources:

- [Zarr 3.0 Migration Guide](https://zarr.readthedocs.io/en/latest/user-guide/v3_migration.html)
- [Release Notes - zarr 3.0.0](https://zarr.readthedocs.io/en/latest/release-notes.html#jan-9-2025)